### PR TITLE
Fix notice when i386 is enabled on debian

### DIFF
--- a/install.html
+++ b/install.html
@@ -41,7 +41,7 @@ $ sudo pacman-key --lsign-key 0xF7A9C9DC4631BD1A</pre>
         <p>To give feedback about these packages, please <a href="https://github.com/majewsky/holo-pacman-repo/issues/new">use GitHub Issues</a>.</p>
         <h2>Debian/Ubuntu packages</h2>
         <p>We offer packages that have been cross-compiled on Arch Linux. Add the following to your <tt>/etc/apt/sources.list</tt>:</p>
-        <pre>deb https://repo.holocm.org/debian stable main</pre>
+        <pre>deb [arch=amd64] https://repo.holocm.org/debian stable main</pre>
         <p>The repository is signed with GPG, so you need to import and trust the signing key:</p>
         <pre>$ sudo apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 0xD6019A3E17CA2D96
 $ sudo apt-key adv --fingerprint 0xD6019A3E17CA2D96


### PR DESCRIPTION
This fixes the following notice:
````
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://repo.holocm.org/debian stable InRelease' doesn't support architecture 'i386'
````